### PR TITLE
Add release GitHub action with tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '.github/workflows/test.yml'
+      - 'examples/**'
+      - '**/*.test.ts'
+      - 'test/**'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: Test, Build and Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run tests
+      run: npm test -- -t ''
+
+    - name: Build project
+      run: npm run build
+
+    - name: Bump version
+      id: version
+      run: |
+        # Configure git
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+
+        # Get current version
+        CURRENT_VERSION=$(node -p "require('./package.json').version")
+        echo "Current version: $CURRENT_VERSION"
+
+        # Bump version
+        npm version patch --no-git-tag-version
+        NEW_VERSION=$(node -p "require('./package.json').version")
+        echo "New version: $NEW_VERSION"
+        echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+        # Commit changes
+        git add package.json package-lock.json
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+          echo "skip_push=true" >> $GITHUB_OUTPUT
+        else
+          git commit -m "chore(release): ${NEW_VERSION} [skip ci]"
+          git tag "v${NEW_VERSION}"
+          echo "skip_push=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Check if we should publish
+      id: should_publish
+      run: |
+        if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+          echo "NPM_TOKEN not set, skipping publish"
+          echo "publish=false" >> $GITHUB_OUTPUT
+        else
+          echo "NPM_TOKEN is set, will publish"
+          echo "publish=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Publish to npm
+      run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      if: steps.should_publish.outputs.publish == 'true'
+
+    - name: Push changes
+      run: |
+        git push origin main
+        git push origin --tags
+      if: steps.version.outputs.skip_push != 'true'

--- a/src/__tests__/design-image.test.ts
+++ b/src/__tests__/design-image.test.ts
@@ -59,15 +59,43 @@ vi.mock('../utils/grid-judge.js', () => ({
     judgeImageSet: vi.fn().mockResolvedValue(['mock-image-1.png'])
 }));
 
+vi.mock('@napi-rs/canvas', () => ({
+    createCanvas: vi.fn().mockReturnValue({
+        getContext: vi.fn().mockReturnValue({
+            drawImage: vi.fn()
+        }),
+        toDataURL: vi.fn().mockReturnValue('data:image/png;base64,mock')
+    }),
+    loadImage: vi.fn().mockResolvedValue({ width: 100, height: 100 })
+}));
+
+vi.mock('sharp', () => {
+    const sharpMock = vi.fn(() => ({
+        metadata: vi.fn().mockResolvedValue({ width: 100 }),
+        resize: vi.fn().mockReturnThis(),
+        toFormat: vi.fn().mockReturnThis(),
+        toBuffer: vi.fn().mockResolvedValue(Buffer.from('mock'))
+    }));
+    return { __esModule: true, default: sharpMock };
+});
+
 vi.mock('fs', () => ({
     default: {
         existsSync: vi.fn().mockReturnValue(true),
         mkdirSync: vi.fn(),
-        writeFileSync: vi.fn()
+        writeFileSync: vi.fn(),
+        statSync: vi.fn().mockReturnValue({
+            isDirectory: () => false,
+            size: 1
+        })
     },
     existsSync: vi.fn().mockReturnValue(true),
     mkdirSync: vi.fn(),
-    writeFileSync: vi.fn()
+    writeFileSync: vi.fn(),
+    statSync: vi.fn().mockReturnValue({
+        isDirectory: () => false,
+        size: 1
+    })
 }));
 
 describe('design_image', () => {

--- a/src/__tests__/design-search.test.ts
+++ b/src/__tests__/design-search.test.ts
@@ -41,26 +41,40 @@ vi.mock('@napi-rs/canvas', () => ({
     })
 }));
 
+vi.mock('../utils/image-registry.js', () => {
+    let id = 1;
+    const registry = {
+        registerImage: vi.fn(async () => id++),
+        registerImageSync: vi.fn(() => id++),
+        getCachedGrid: vi.fn(() => null),
+        cacheGrid: vi.fn(),
+        getImage: vi.fn().mockReturnValue({ path: '/tmp/mock.png' })
+    };
+    return {
+        getImageRegistry: () => registry
+    };
+});
+
 // Removed design_search integration tests that try to browse real websites and timeout
 
 describe('createNumberedGrid', () => {
     it('should create a grid from image sources', async () => {
         const imagesSources = [
-            { url: 'http://example.com/image1.png', title: 'Image 1' },
-            { url: 'http://example.com/image2.png', title: 'Image 2' },
-            { dataUrl: 'data:image/png;base64,mockData', title: 'Image 3' }
+            { url: 'data:image/png;base64,image1', title: 'Image 1' },
+            { url: 'data:image/png;base64,image2', title: 'Image 2' },
+            { url: 'data:image/png;base64,image3', title: 'Image 3' }
         ];
 
         const result = await createNumberedGrid(imagesSources, 'test-grid');
         
         expect(result).toBeDefined();
         expect(typeof result).toBe('string');
-        expect(result.startsWith('data:image/png;base64,')).toBe(true);
+        expect(result.endsWith('.png')).toBe(true);
     });
 
     it('should handle different aspect ratios', async () => {
         const imagesSources = [
-            { url: 'http://example.com/image1.png' }
+            { url: 'data:image/png;base64,image1' }
         ];
 
         const landscapeResult = await createNumberedGrid(imagesSources, 'landscape-test', 'landscape');


### PR DESCRIPTION
## Summary
- mock canvas and sharp in tests to avoid native image processing
- stub image registry and use data URLs in design search tests
- add a `release` workflow that runs tests and publishes to npm

## Testing
- `npm test -- -t ''`

------
https://chatgpt.com/codex/tasks/task_e_6869a34da6ac832a8b6b5a9dc2e7003c