### PR TITLE
Add client-side API key input and update demo-ui dependency

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "design-demo",
       "version": "0.0.0",
       "dependencies": {
-        "@just-every/demo-ui": "file:../../demo-ui",
+        "@just-every/demo-ui": "^0.1.1",
         "d3": "^7.9.0",
         "dompurify": "^3.2.3",
         "dotenv": "^17.0.1",
@@ -29,37 +29,6 @@
         "tailwindcss": "^3.4.15",
         "typescript": "^5.7.3",
         "vite": "^6.0.7"
-      }
-    },
-    "../../demo-ui": {
-      "name": "@just-every/demo-ui",
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "^3.0.0",
-        "isomorphic-dompurify": "^2.0.0",
-        "marked": "^9.0.0"
-      },
-      "devDependencies": {
-        "@rollup/plugin-commonjs": "^25.0.0",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^15.0.0",
-        "@types/dompurify": "^3.0.0",
-        "@types/react": "^18.0.0",
-        "@types/react-dom": "^18.0.0",
-        "@typescript-eslint/eslint-plugin": "^6.0.0",
-        "@typescript-eslint/parser": "^6.0.0",
-        "eslint": "^8.0.0",
-        "rollup": "^4.0.0",
-        "rollup-plugin-postcss": "^4.0.0",
-        "rollup-plugin-typescript2": "^0.36.0",
-        "sass": "^1.89.2",
-        "typescript": "^5.0.0",
-        "vitest": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -88,6 +57,25 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -369,6 +357,116 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -854,8 +952,31 @@
       }
     },
     "node_modules/@just-every/demo-ui": {
-      "resolved": "../../demo-ui",
-      "link": true
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@just-every/demo-ui/-/demo-ui-0.1.1.tgz",
+      "integrity": "sha512-dpVxcS8VMCx67JFVH/hgJm1sveswaWIk8ByGTi79E/b+Ah8gTUXTl05sPWD+P6cUgd6NAngN3QsgZwMBlKyPVA==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.0.0",
+        "isomorphic-dompurify": "^2.0.0",
+        "marked": "^9.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@just-every/demo-ui/node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1913,6 +2034,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -2190,6 +2320,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/csstype": {
@@ -2600,11 +2743,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2617,6 +2772,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "license": "MIT"
     },
     "node_modules/delaunator": {
       "version": "5.0.1",
@@ -2696,6 +2857,18 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -2914,6 +3087,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -3014,12 +3225,31 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-dompurify": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.25.0.tgz",
+      "integrity": "sha512-bcpJzu9DOjN21qaCVpcoCwUX1ytpvA6EFqCK5RNtPg5+F0Jz9PX50jl6jbEicBNeO87eDDfC7XtPs4zjDClZJg==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.2.6",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3052,6 +3282,45 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3187,7 +3456,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -3256,6 +3524,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3282,6 +3556,18 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -3514,6 +3800,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3678,6 +3973,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3733,6 +4034,18 @@
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3950,6 +4263,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -4107,6 +4426,24 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4118,6 +4455,30 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -4282,6 +4643,61 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4395,6 +4811,42 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/demo/package.json
+++ b/demo/package.json
@@ -12,7 +12,7 @@
     "start": "npm run build && node server.js"
   },
   "dependencies": {
-    "@just-every/demo-ui": "file:../../demo-ui",
+    "@just-every/demo-ui": "^0.1.1",
     "d3": "^7.9.0",
     "dompurify": "^3.2.3",
     "dotenv": "^17.0.1",

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -9,6 +9,7 @@ import ImageGallery from './components/ImageGallery'
 import LLMRequestLog from './components/LLMRequestLog'
 import ReportView from './components/ReportView'
 import ConversationView from './components/ConversationView'
+import ApiKeysForm, { ApiKeys } from './components/ApiKeysForm'
 import { useDesignRunner } from './hooks/useDesignRunner'
 import { DesignState, LLMRequest } from './types'
 import './App.scss'
@@ -26,6 +27,14 @@ function App() {
   const [totalTokens, setTotalTokens] = useState(0)
   const [totalCost, setTotalCost] = useState(0)
   const [withInspiration, setWithInspiration] = useState(true)
+  const [apiKeys, setApiKeys] = useState<ApiKeys>(() => {
+    if (typeof window === 'undefined') return {}
+    try {
+      return JSON.parse(localStorage.getItem('demo_api_keys') || '{}')
+    } catch {
+      return {}
+    }
+  })
 
   const { runDesign, stopDesign, connect } = useDesignRunner({
     onStateUpdate: setDesignState,
@@ -49,7 +58,8 @@ function App() {
         setTotalTokens(prev => prev + request.response!.usage.totalTokens)
         setTotalCost(prev => prev + (request.response!.usage.totalTokens * 0.00001)) // Mock cost calculation
       }
-    }
+    },
+    apiKeys
   })
 
   // Connect to WebSocket on mount
@@ -114,7 +124,11 @@ function App() {
         </div>
 
         <Card>
-          <DesignExamples 
+          <ApiKeysForm apiKeys={apiKeys} onChange={setApiKeys} />
+        </Card>
+
+        <Card>
+          <DesignExamples
             selectedExample={selectedExample}
             onSelectExample={setSelectedExample}
             selectedAssetType={selectedAssetType}

--- a/demo/src/components/ApiKeysForm.tsx
+++ b/demo/src/components/ApiKeysForm.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { GlassButton, Card } from '@just-every/demo-ui'
+
+export interface ApiKeys {
+  openai?: string
+  anthropic?: string
+  google?: string
+  xai?: string
+}
+
+interface Props {
+  apiKeys: ApiKeys
+  onChange: (keys: ApiKeys) => void
+}
+
+export default function ApiKeysForm({ apiKeys, onChange }: Props) {
+  const [openai, setOpenai] = useState(apiKeys.openai || '')
+  const [anthropic, setAnthropic] = useState(apiKeys.anthropic || '')
+  const [google, setGoogle] = useState(apiKeys.google || '')
+  const [xai, setXai] = useState(apiKeys.xai || '')
+
+  const save = () => {
+    const newKeys = { openai, anthropic, google, xai }
+    onChange(newKeys)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('demo_api_keys', JSON.stringify(newKeys))
+    }
+  }
+
+  return (
+    <Card style={{ padding: '12px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div>
+        <input placeholder="OPENAI_API_KEY" value={openai} onChange={e => setOpenai(e.target.value)} style={{ width: '100%' }} />
+      </div>
+      <div>
+        <input placeholder="ANTHROPIC_API_KEY" value={anthropic} onChange={e => setAnthropic(e.target.value)} style={{ width: '100%' }} />
+      </div>
+      <div>
+        <input placeholder="GOOGLE_API_KEY" value={google} onChange={e => setGoogle(e.target.value)} style={{ width: '100%' }} />
+      </div>
+      <div>
+        <input placeholder="XAI_API_KEY" value={xai} onChange={e => setXai(e.target.value)} style={{ width: '100%' }} />
+      </div>
+      <div style={{ marginTop: '8px' }}>
+        <GlassButton onClick={save}>Save Keys</GlassButton>
+      </div>
+    </Card>
+  )
+}

--- a/demo/src/hooks/useDesignRunner.ts
+++ b/demo/src/hooks/useDesignRunner.ts
@@ -1,169 +1,17 @@
-import { useRef, useCallback, useState } from 'react'
+import useDesignRunnerServer from './useDesignRunnerServer'
+import useDesignRunnerClient from './useDesignRunnerClient'
+import type { ApiKeys } from '../components/ApiKeysForm'
 import { DesignState, LLMRequest } from '../types'
 
-interface UseDesignRunnerOptions {
+interface Options {
   onStateUpdate: (state: DesignState | null) => void
   onLLMRequest: (request: LLMRequest) => void
+  apiKeys?: ApiKeys
 }
 
-export function useDesignRunner({ onStateUpdate, onLLMRequest }: UseDesignRunnerOptions) {
-  const wsRef = useRef<WebSocket | null>(null)
-  const isConnectedRef = useRef(false)
-  const [, setLLMRequests] = useState<LLMRequest[]>([])
-
-  const connect = useCallback(() => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      return
-    }
-
-    const ws = new WebSocket('ws://localhost:3456')
-
-    ws.onopen = () => {
-      console.log('Connected to design server')
-      isConnectedRef.current = true
-    }
-
-    ws.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data)
-        
-        switch (data.type) {
-          case 'design_state':
-            onStateUpdate(data.state)
-            break
-            
-          case 'design_complete':
-            onStateUpdate(data.state)
-            break
-            
-          case 'design_error':
-            onStateUpdate(data.state)
-            break
-            
-          case 'llm_request':
-            const newRequest: LLMRequest = {
-              id: data.id,
-              agentId: data.agentId,
-              provider: data.provider,
-              model: data.model,
-              timestamp: data.timestamp,
-              messages: data.messages,
-              temperature: data.temperature,
-              maxTokens: data.maxTokens
-            }
-            setLLMRequests(prev => [...prev, newRequest])
-            onLLMRequest(newRequest)
-            break
-            
-          case 'llm_response':
-            // Find and update the request
-            setLLMRequests(requests => {
-              const updated = requests.map(req => 
-                req.id === data.requestId 
-                  ? {
-                      ...req,
-                      response: {
-                        content: data.content,
-                        usage: data.usage,
-                        duration: data.duration
-                      }
-                    }
-                  : req
-              )
-              // Also notify via callback
-              const updatedReq = updated.find(r => r.id === data.requestId)
-              if (updatedReq) onLLMRequest(updatedReq)
-              return updated
-            })
-            break
-            
-          case 'llm_error':
-            // Find and update the request with error
-            setLLMRequests(requests => {
-              const updated = requests.map(req => 
-                req.id === data.requestId 
-                  ? {
-                      ...req,
-                      error: data.error
-                    }
-                  : req
-              )
-              // Also notify via callback
-              const updatedReq = updated.find(r => r.id === data.requestId)
-              if (updatedReq) onLLMRequest(updatedReq)
-              return updated
-            })
-            break
-            
-          case 'stream_text':
-            // Handle streaming text if needed
-            console.log('Stream text:', data.text)
-            break
-            
-          case 'tool_use':
-            console.log('Tool use:', data.tool, data.input)
-            break
-            
-          case 'tool_result':
-            console.log('Tool result:', data.tool, data.result)
-            break
-        }
-      } catch (error) {
-        console.error('Error parsing message:', error)
-      }
-    }
-
-    ws.onerror = (error) => {
-      console.error('WebSocket error:', error)
-    }
-
-    ws.onclose = () => {
-      console.log('Disconnected from design server')
-      isConnectedRef.current = false
-    }
-
-    wsRef.current = ws
-  }, [onStateUpdate, onLLMRequest])
-
-  const runDesign = useCallback(async (prompt: string, assetType?: string, withInspiration: boolean = true) => {
-    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
-      connect()
-      // Wait for connection
-      await new Promise((resolve) => {
-        const checkConnection = setInterval(() => {
-          if (wsRef.current?.readyState === WebSocket.OPEN) {
-            clearInterval(checkConnection)
-            resolve(true)
-          }
-        }, 100)
-      })
-    }
-
-    wsRef.current?.send(JSON.stringify({
-      type: 'run_design',
-      prompt,
-      assetType,
-      withInspiration
-    }))
-  }, [connect])
-
-  const stopDesign = useCallback(() => {
-    wsRef.current?.send(JSON.stringify({
-      type: 'stop_design'
-    }))
-  }, [])
-
-  const getImage = useCallback((path: string) => {
-    wsRef.current?.send(JSON.stringify({
-      type: 'get_image',
-      path
-    }))
-  }, [])
-
-  return {
-    runDesign,
-    stopDesign,
-    getImage,
-    connect
+export function useDesignRunner(options: Options) {
+  if (options.apiKeys && Object.values(options.apiKeys).some(k => k)) {
+    return useDesignRunnerClient({ ...options, apiKeys: options.apiKeys })
   }
+  return useDesignRunnerServer(options)
 }

--- a/demo/src/hooks/useDesignRunnerClient.ts
+++ b/demo/src/hooks/useDesignRunnerClient.ts
@@ -1,0 +1,53 @@
+import { useCallback } from 'react'
+import { runDesignAgentStreaming } from '../../../src/index.js'
+import { DesignState, LLMRequest } from '../types'
+import type { ApiKeys } from '../components/ApiKeysForm'
+
+interface Options {
+  onStateUpdate: (state: DesignState | null) => void
+  onLLMRequest: (request: LLMRequest) => void
+  apiKeys: ApiKeys
+}
+
+export default function useDesignRunnerClient({ onStateUpdate, onLLMRequest, apiKeys }: Options) {
+  const runDesign = useCallback(async (prompt: string, assetType?: string, withInspiration = true) => {
+    if (apiKeys.openai) (process.env as any).OPENAI_API_KEY = apiKeys.openai
+    if (apiKeys.anthropic) (process.env as any).ANTHROPIC_API_KEY = apiKeys.anthropic
+    if (apiKeys.google) (process.env as any).GOOGLE_API_KEY = apiKeys.google
+    if (apiKeys.xai) (process.env as any).XAI_API_KEY = apiKeys.xai
+
+    const state: DesignState = {
+      id: `design_${Date.now()}`,
+      prompt,
+      assetType: assetType as any,
+      withInspiration,
+      startTime: new Date(),
+      status: 'running',
+      messages: [],
+      phases: []
+    }
+    onStateUpdate({ ...state })
+
+    try {
+      for await (const event of runDesignAgentStreaming(assetType as any, prompt, withInspiration)) {
+        if (event.type === 'message') {
+          state.messages.push(event.data)
+        } else if (event.type === 'stream-event' && event.data.type === 'text') {
+          // no-op for now
+        }
+      }
+      state.status = 'completed'
+      state.endTime = new Date()
+    } catch (err: any) {
+      state.status = 'error'
+      state.error = err.message
+    }
+    onStateUpdate({ ...state })
+  }, [apiKeys, onStateUpdate])
+
+  const stopDesign = useCallback(() => {
+    // client run cannot be stopped yet
+  }, [])
+
+  return { runDesign, stopDesign, getImage: () => {}, connect: () => {} }
+}

--- a/demo/src/hooks/useDesignRunnerServer.ts
+++ b/demo/src/hooks/useDesignRunnerServer.ts
@@ -1,0 +1,169 @@
+import { useRef, useCallback, useState } from 'react'
+import { DesignState, LLMRequest } from '../types'
+
+interface UseDesignRunnerOptions {
+  onStateUpdate: (state: DesignState | null) => void
+  onLLMRequest: (request: LLMRequest) => void
+}
+
+export function useDesignRunner({ onStateUpdate, onLLMRequest }: UseDesignRunnerOptions) {
+  const wsRef = useRef<WebSocket | null>(null)
+  const isConnectedRef = useRef(false)
+  const [, setLLMRequests] = useState<LLMRequest[]>([])
+
+  const connect = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      return
+    }
+
+    const ws = new WebSocket('ws://localhost:3456')
+
+    ws.onopen = () => {
+      console.log('Connected to design server')
+      isConnectedRef.current = true
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data)
+        
+        switch (data.type) {
+          case 'design_state':
+            onStateUpdate(data.state)
+            break
+            
+          case 'design_complete':
+            onStateUpdate(data.state)
+            break
+            
+          case 'design_error':
+            onStateUpdate(data.state)
+            break
+            
+          case 'llm_request':
+            const newRequest: LLMRequest = {
+              id: data.id,
+              agentId: data.agentId,
+              provider: data.provider,
+              model: data.model,
+              timestamp: data.timestamp,
+              messages: data.messages,
+              temperature: data.temperature,
+              maxTokens: data.maxTokens
+            }
+            setLLMRequests(prev => [...prev, newRequest])
+            onLLMRequest(newRequest)
+            break
+            
+          case 'llm_response':
+            // Find and update the request
+            setLLMRequests(requests => {
+              const updated = requests.map(req => 
+                req.id === data.requestId 
+                  ? {
+                      ...req,
+                      response: {
+                        content: data.content,
+                        usage: data.usage,
+                        duration: data.duration
+                      }
+                    }
+                  : req
+              )
+              // Also notify via callback
+              const updatedReq = updated.find(r => r.id === data.requestId)
+              if (updatedReq) onLLMRequest(updatedReq)
+              return updated
+            })
+            break
+            
+          case 'llm_error':
+            // Find and update the request with error
+            setLLMRequests(requests => {
+              const updated = requests.map(req => 
+                req.id === data.requestId 
+                  ? {
+                      ...req,
+                      error: data.error
+                    }
+                  : req
+              )
+              // Also notify via callback
+              const updatedReq = updated.find(r => r.id === data.requestId)
+              if (updatedReq) onLLMRequest(updatedReq)
+              return updated
+            })
+            break
+            
+          case 'stream_text':
+            // Handle streaming text if needed
+            console.log('Stream text:', data.text)
+            break
+            
+          case 'tool_use':
+            console.log('Tool use:', data.tool, data.input)
+            break
+            
+          case 'tool_result':
+            console.log('Tool result:', data.tool, data.result)
+            break
+        }
+      } catch (error) {
+        console.error('Error parsing message:', error)
+      }
+    }
+
+    ws.onerror = (error) => {
+      console.error('WebSocket error:', error)
+    }
+
+    ws.onclose = () => {
+      console.log('Disconnected from design server')
+      isConnectedRef.current = false
+    }
+
+    wsRef.current = ws
+  }, [onStateUpdate, onLLMRequest])
+
+  const runDesign = useCallback(async (prompt: string, assetType?: string, withInspiration: boolean = true) => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+      connect()
+      // Wait for connection
+      await new Promise((resolve) => {
+        const checkConnection = setInterval(() => {
+          if (wsRef.current?.readyState === WebSocket.OPEN) {
+            clearInterval(checkConnection)
+            resolve(true)
+          }
+        }, 100)
+      })
+    }
+
+    wsRef.current?.send(JSON.stringify({
+      type: 'run_design',
+      prompt,
+      assetType,
+      withInspiration
+    }))
+  }, [connect])
+
+  const stopDesign = useCallback(() => {
+    wsRef.current?.send(JSON.stringify({
+      type: 'stop_design'
+    }))
+  }, [])
+
+  const getImage = useCallback((path: string) => {
+    wsRef.current?.send(JSON.stringify({
+      type: 'get_image',
+      path
+    }))
+  }, [])
+
+  return {
+    runDesign,
+    stopDesign,
+    getImage,
+    connect
+  }
+}


### PR DESCRIPTION
## Summary
- update demo package to use published `@just-every/demo-ui`
- add `ApiKeysForm` component for entering API keys in the demo UI
- split design runner hook into server and client versions
- auto choose runner based on provided keys
- pass API keys from the UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869b3165a7c832ab4b74793f6572d0e